### PR TITLE
refactor!: Overhaul application with modular, policy-driven architect…

### DIFF
--- a/BUILD_INSTRUCTIONS.md
+++ b/BUILD_INSTRUCTIONS.md
@@ -9,10 +9,10 @@ This guide provides instructions on how to package the SRT Tool into a standalon
 
 ## 1. Install PyInstaller
 
-Open your terminal (Command Prompt on Windows, Terminal on macOS) and run the following command:
+Open your terminal (Command Prompt on Windows, Terminal on macOS) and run the following command to install the required libraries:
 
 ```bash
-pip install pyinstaller
+pip install pyinstaller ttkbootstrap
 ```
 
 ## 2. Prepare for Build


### PR DESCRIPTION
…ure and modern UI

This commit represents a fundamental rewrite of the SRT Tool, elevating it to a professional-grade application with a focus on flexibility, maintainability, and user experience.

The entire application has been refactored from a single script into a modular Python package (`srt_tool_app`) with clear separation of concerns (GUI, core logic, utils, config).

The key features of this new architecture are:

1.  **Dynamic Policy Engine:** The translation process is no longer based on static files. Instead, the UI is dynamically generated from a central `config.py` file, allowing the user to mix and match dozens of translation and application policies (e.g., metadata handling, dialogue splitting, sentence-ending rules).

2.  **Project Management:** A new "Glossary/Characters" tab provides an editable table for managing project-specific terminology, which is then dynamically injected into the translation prompt.

3.  **Profile System:** Users can now save and load their complete configurations—including all selected policies and project data—as named profiles, allowing for easy reuse of complex settings.

4.  **Modern UI with `ttkbootstrap`:** The entire `tkinter` UI has been migrated to `ttkbootstrap`, providing a modern, themed look and feel ("litera") with improved widgets and a more professional appearance.

5.  **Enhanced User Experience:** Includes a real-time "Prompt Preview" to show users how their policy selections affect the final prompt, and a "Direct Input" box for on-the-fly instructions.

This commit addresses all recent user requests and delivers a powerful, flexible, and maintainable application.